### PR TITLE
Fix: use sample-size weighted mean in compute_state_prevalence (fixes #21)

### DIFF
--- a/src/compute_prevalence.py
+++ b/src/compute_prevalence.py
@@ -2,6 +2,7 @@
 
 Simple helper to compute prevalence summaries from the combined BRFSS dataset.
 """
+
 from pathlib import Path
 import pandas as pd
 
@@ -9,18 +10,28 @@ import pandas as pd
 def compute_state_prevalence(df: pd.DataFrame) -> pd.DataFrame:
     """Return a state-year-indicator prevalence table.
 
-    Expects df with columns: year,state,measure,value,ci_lower,ci_upper,sample_size
+    Expects df with columns: year, state, measure, value, sample_size
+    and computes a sample-size-weighted prevalence_pct.
     """
-    required = ["year","state","measure","value"]
+    required = ["year", "state", "measure", "value", "sample_size"]
     for r in required:
         if r not in df.columns:
             raise ValueError(f"DataFrame missing required column: {r}")
-    out = df.groupby(["year","state","measure"], as_index=False).agg(
-        prevalence_pct=("value","mean"),
-        sample_size=("sample_size","sum")
+            
+    out = df.copy()
+    out["weighted"] = out["value"] * out["sample_size"]
+
+    out = out.groupby(["year", "state", "measure"], as_index=False).agg(
+        weighted_sum=("weighted", "sum"),
+        sample_size=("sample_size", "sum"),
     )
+
+    out["prevalence_pct"] = out["weighted_sum"] / out["sample_size"]
+
+    out = out[["year", "state", "measure", "prevalence_pct", "sample_size"]]
+
     return out
+    
 
-
-def load_combined(path: Path):
+def load_combined(path: Path) -> pd.DataFrame:
     return pd.read_csv(path)

--- a/tests/test_compute_prevalence
+++ b/tests/test_compute_prevalence
@@ -1,0 +1,32 @@
+import pandas as pd
+from src.compute_prevalence import compute_state_prevalence
+
+
+def test_compute_state_prevalence_uses_weighted_mean():
+    """
+    Verify that compute_state_prevalence uses a sample-size weighted mean.
+
+    Given multiple rows for the same year/state/measure, the function should:
+    - weight each value by its sample_size
+    - aggregate sample sizes
+    - compute prevalence as weighted_sum / total_sample_size
+
+    This ensures consistency with the weighted aggregation used elsewhere
+    in the pipeline and prevents incorrect unweighted averages.
+    """
+    df = pd.DataFrame({
+        "year": [2023, 2023],
+        "state": ["VA", "VA"],
+        "measure": ["obesity", "obesity"],
+        "value": [10.0, 30.0],
+        "sample_size": [100, 300],
+    })
+
+    result = compute_state_prevalence(df)
+
+    assert len(result) == 1
+    assert result.loc[0, "year"] == 2023
+    assert result.loc[0, "state"] == "VA"
+    assert result.loc[0, "measure"] == "obesity"
+    assert result.loc[0, "sample_size"] == 400
+    assert result.loc[0, "prevalence_pct"] == 25.0


### PR DESCRIPTION
**Summary**
Fixes compute_state_prevalence so state-level prevalence is computed using a sample-size weighted mean instead of an unweighted mean.

**Problem**
The previous implementation used a simple arithmetic mean, which could produce incorrect results when multiple rows existed for the same year/state/measure.

**Changes**

1) Replaced unweighted mean with weighted mean: 
- weighted = value * sample_size
- prevalence_pct = sum(weighted) / sum(sample_size)

2) Added validation requiring sample_size column

3) Added a unit test to verify that function computes sample-size weighted mean instead of an unweighted mean

**Why this matters**
This makes state-level prevalence consistent with the weighted aggregation already used in trend_analysis.py and ensures statistically correct outputs.

Issue: Fixes #21

