### PR TITLE
Add upfront DataFrame validation at module entry points (#42)

### DIFF
--- a/src/covid_analysis.py
+++ b/src/covid_analysis.py
@@ -2,20 +2,21 @@
 
 Dedicated module for COVID-era trend-shift analysis across U.S. regions.
 
-This module goes beyond the basic pre/post comparison in trend_analysis.py
-and provides a fuller picture of how the COVID-19 pandemic (2020) disrupted
-health trends in obesity, healthcare coverage, and smoking prevalence.
+This module goes beyond the basic pre/post comparison in trend_analysis.py and
+provides a fuller picture of how the COVID-19 pandemic (2020) disrupted health
+trends in obesity, healthcare coverage, and smoking prevalence.
 
 Questions answered:
-- Which regions saw the sharpest acceleration or reversal post-COVID?
-- Did 2020 act as a structural break in the trend for any measure?
-- How quickly did each region recover toward its pre-COVID trajectory?
-- Which measure was most disrupted by COVID across all regions?
-
+    - Which regions saw the sharpest acceleration or reversal post-COVID?
+    - Did 2020 act as a structural break in the trend for any measure?
+    - How quickly did each region recover toward its pre-COVID trajectory?
+    - Which measure was most disrupted by COVID across all regions?
 """
 
 import numpy as np
 import pandas as pd
+
+from src.utils import validate_dataframe
 
 COVID_YEAR = 2020
 PRE_COVID_WINDOW = (2017, 2019)
@@ -40,12 +41,14 @@ def compute_slope(years: np.ndarray, values: np.ndarray) -> float:
     coeffs = np.polyfit(years, values, 1)
     return round(float(coeffs[0]), 4)
 
+
 def compare_trend_slopes(
     regional_ts: pd.DataFrame,
     pre: tuple = PRE_COVID_WINDOW,
     post: tuple = POST_COVID_WINDOW,
 ) -> pd.DataFrame:
     """Compare the trend slope (pp/year) before vs after COVID per region.
+
     A positive slope_shift means the measure is rising faster post-COVID.
     A negative slope_shift means it slowed down or reversed post-COVID.
 
@@ -59,11 +62,11 @@ def compare_trend_slopes(
     -------
     DataFrame with columns: region, pre_slope, post_slope, slope_shift
     """
-    required = {"region", "year", "prevalence_pct"}
-    missing = required - set(regional_ts.columns)
-    if missing:
-        raise ValueError(f"Missing required columns: {sorted(missing)}")
-
+    validate_dataframe(
+        regional_ts,
+        ["region", "year", "prevalence_pct"],
+        name="regional_ts (compare_trend_slopes)",
+    )
     ts = _filter_valid_regions(regional_ts)
     records = []
     for region, group in ts.groupby("region"):
@@ -76,9 +79,7 @@ def compare_trend_slopes(
             if not (np.isnan(pre_slope) or np.isnan(post_slope))
             else float("nan")
         )
-        records.append({"region": region, "pre_slope": pre_slope,
-                        "post_slope": post_slope, "slope_shift": slope_shift})
-
+        records.append({"region": region, "pre_slope": pre_slope, "post_slope": post_slope, "slope_shift": slope_shift})
     if not records:
         return pd.DataFrame(columns=["region", "pre_slope", "post_slope", "slope_shift"])
     return (pd.DataFrame(records)
@@ -92,6 +93,7 @@ def compute_disruption_score(
     post: tuple = POST_COVID_WINDOW,
 ) -> pd.DataFrame:
     """Compute a disruption score for each region based on COVID impact.
+
     Score = abs(delta) + abs(slope_shift) * 10
     Higher score means COVID had a larger measurable effect.
 
@@ -103,21 +105,19 @@ def compute_disruption_score(
 
     Returns
     -------
-    DataFrame with columns:
-        region, pre_avg, post_avg, delta, slope_shift, disruption_score
+    DataFrame with columns: region, pre_avg, post_avg, delta, slope_shift, disruption_score
     """
-    required = {"region", "year", "prevalence_pct"}
-    missing = required - set(regional_ts.columns)
-    if missing:
-        raise ValueError(f"Missing required columns: {sorted(missing)}")
-
+    validate_dataframe(
+        regional_ts,
+        ["region", "year", "prevalence_pct"],
+        name="regional_ts (compute_disruption_score)",
+    )
     ts = _filter_valid_regions(regional_ts)
     pre_avg = (ts[ts["year"].between(pre[0], pre[1])]
                .groupby("region")["prevalence_pct"].mean().rename("pre_avg"))
     post_avg = (ts[ts["year"].between(post[0], post[1])]
                 .groupby("region")["prevalence_pct"].mean().rename("post_avg"))
     slopes = compare_trend_slopes(ts, pre=pre, post=post).set_index("region")
-
     result = pd.concat([pre_avg, post_avg], axis=1).reset_index()
     result.columns = ["region", "pre_avg", "post_avg"]
     result["delta"] = (result["post_avg"] - result["pre_avg"]).round(2)
@@ -138,16 +138,25 @@ def rank_measures_by_disruption(
     Parameters
     ----------
     all_region_ts_by_measure : dict
-        Keys are measure names, values are DataFrames with
-        region, year, prevalence_pct columns.
+        Keys are measure names, values are DataFrames with region, year,
+        prevalence_pct columns.
 
     Returns
     -------
-    DataFrame with columns:
-        measure, avg_disruption_score, max_disruption_region, max_disruption_score
+    DataFrame with columns: measure, avg_disruption_score, max_disruption_region, max_disruption_score
     """
+    if not isinstance(all_region_ts_by_measure, dict):
+        raise TypeError(
+            "all_region_ts_by_measure must be a dict of {measure: DataFrame}, "
+            f"got {type(all_region_ts_by_measure).__name__}"
+        )
     records = []
     for measure, ts in all_region_ts_by_measure.items():
+        validate_dataframe(
+            ts,
+            ["region", "year", "prevalence_pct"],
+            name=f"all_region_ts_by_measure[{measure!r}]",
+        )
         if ts.empty:
             continue
         scores = compute_disruption_score(ts, pre=pre, post=post)
@@ -165,6 +174,7 @@ def rank_measures_by_disruption(
     return (pd.DataFrame(records)
             .sort_values("avg_disruption_score", ascending=False)
             .reset_index(drop=True))
+
 
 def compute_recovery_trajectory(
     regional_ts: pd.DataFrame,
@@ -188,11 +198,11 @@ def compute_recovery_trajectory(
     -------
     DataFrame with columns: region, year, actual, projected, gap
     """
-    required = {"region", "year", "prevalence_pct"}
-    missing = required - set(regional_ts.columns)
-    if missing:
-        raise ValueError(f"Missing required columns: {sorted(missing)}")
-
+    validate_dataframe(
+        regional_ts,
+        ["region", "year", "prevalence_pct"],
+        name="regional_ts (compute_recovery_trajectory)",
+    )
     ts = _filter_valid_regions(regional_ts)
     records = []
     for region, group in ts.groupby("region"):
@@ -216,6 +226,7 @@ def compute_recovery_trajectory(
         return pd.DataFrame(columns=["region", "year", "actual", "projected", "gap"])
     return pd.DataFrame(records).sort_values(["region", "year"]).reset_index(drop=True)
 
+
 def build_covid_summary_table(
     all_region_ts_by_measure: dict,
     pre: tuple = PRE_COVID_WINDOW,
@@ -226,8 +237,8 @@ def build_covid_summary_table(
     Parameters
     ----------
     all_region_ts_by_measure : dict
-        Keys are measure names, values are DataFrames with
-        region, year, prevalence_pct columns.
+        Keys are measure names, values are DataFrames with region, year,
+        prevalence_pct columns.
 
     Returns
     -------
@@ -235,8 +246,18 @@ def build_covid_summary_table(
         measure, region, pre_avg, post_avg, delta, pct_change,
         pre_slope, post_slope, slope_shift, disruption_score
     """
+    if not isinstance(all_region_ts_by_measure, dict):
+        raise TypeError(
+            "all_region_ts_by_measure must be a dict of {measure: DataFrame}, "
+            f"got {type(all_region_ts_by_measure).__name__}"
+        )
     all_frames = []
     for measure, ts in all_region_ts_by_measure.items():
+        validate_dataframe(
+            ts,
+            ["region", "year", "prevalence_pct"],
+            name=f"all_region_ts_by_measure[{measure!r}]",
+        )
         if ts.empty:
             continue
         disruption = compute_disruption_score(ts, pre=pre, post=post)
@@ -251,10 +272,8 @@ def build_covid_summary_table(
         disruption["slope_shift"] = disruption["region"].map(slopes["slope_shift"])
         disruption.insert(0, "measure", measure)
         all_frames.append(disruption)
-
     if not all_frames:
         return pd.DataFrame()
-
     return (
         pd.concat(all_frames, ignore_index=True)
         .sort_values(["measure", "disruption_score"], ascending=[True, False])

--- a/src/cross_measure.py
+++ b/src/cross_measure.py
@@ -3,10 +3,10 @@
 Compare obesity, coverage, and smoking trends within a single region.
 
 This module answers questions like:
-- How do different health measures trend together over time in one region?
-- Are obesity and coverage correlated at the state level?
-- Which measure changed the most in a given region?
-- What does a region's health profile look like in a snapshot year?
+    - How do different health measures trend together over time in one region?
+    - Are obesity and coverage correlated at the state level?
+    - Which measure changed the most in a given region?
+    - What does a region's health profile look like in a snapshot year?
 
 Author: Aryan Thodupunuri
 """
@@ -15,9 +15,17 @@ import numpy as np
 import pandas as pd
 
 from src.region_mapping import STATE_TO_REGION
+from src.utils import validate_dataframe
 
 # Default measures the project tracks
 DEFAULT_MEASURES = ["obesity", "coverage", "smoking"]
+
+# Columns required for the public entry points. We accept either a 'state'
+# or 'region' column for routing, plus the long-format measure/value/sample_size
+# triple. Each public function calls validate_dataframe at the top so a
+# malformed/renamed CSV produces an immediate, actionable error instead
+# of a silent miscalculation.
+_REQUIRED_LONG_COLS = ["year", "measure", "value", "sample_size"]
 
 
 def _add_region(df: pd.DataFrame) -> pd.DataFrame:
@@ -55,16 +63,16 @@ def compare_measures_over_time(
     -------
     DataFrame with columns: year, measure, prevalence_pct, sample_size_total
     """
+    validate_dataframe(
+        df,
+        _REQUIRED_LONG_COLS,
+        name="df (compare_measures_over_time)",
+    )
     if measures is None:
         measures = DEFAULT_MEASURES
 
     df = _add_region(df)
     region_df = df[df["region"] == region]
-
-    required = ["year", "measure", "value", "sample_size"]
-    missing = [c for c in required if c not in region_df.columns]
-    if missing:
-        raise ValueError(f"DataFrame missing required columns: {missing}")
 
     frames = []
     for m in measures:
@@ -94,11 +102,10 @@ def compute_measure_correlations(
 ) -> pd.DataFrame:
     """Compute pairwise Pearson correlations between measures.
 
-    At the *state* level (default), this answers: "In the West, do states with
-    high obesity also tend to have low coverage?"
-
-    At the *year* level, this answers: "Over time, do obesity and coverage move
-    together in this region?"
+    At the *state* level (default), this answers:
+        "In the West, do states with high obesity also tend to have low coverage?"
+    At the *year* level, this answers:
+        "Over time, do obesity and coverage move together in this region?"
 
     Parameters
     ----------
@@ -111,16 +118,25 @@ def compute_measure_correlations(
     level : {'state', 'year'}
         Aggregation level for the correlation.
         - 'state': average each measure per state across all years, then correlate.
-        - 'year': average each measure per year across states, then correlate.
+        - 'year':  average each measure per year across states, then correlate.
 
     Returns
     -------
-    DataFrame — a correlation matrix (measures × measures).
+    DataFrame -- a correlation matrix (measures x measures).
     """
     if measures is None:
         measures = DEFAULT_MEASURES
     if level not in ("state", "year"):
         raise ValueError(f"level must be 'state' or 'year', got {level!r}")
+
+    required = list(_REQUIRED_LONG_COLS)
+    if level == "state" and "state" not in df.columns and "region" not in df.columns:
+        required.append("state")
+    validate_dataframe(
+        df,
+        required,
+        name="df (compute_measure_correlations)",
+    )
 
     df = _add_region(df)
     region_df = df[df["region"] == region]
@@ -131,14 +147,12 @@ def compute_measure_correlations(
         return pd.DataFrame(index=measures, columns=measures, dtype=float)
 
     sub["weighted"] = sub["value"] * sub["sample_size"]
-
     group_cols = [level, "measure"]
     agg = sub.groupby(group_cols, as_index=False).agg(
         weighted_sum=("weighted", "sum"),
         sample_size_total=("sample_size", "sum"),
     )
     agg["prevalence_pct"] = agg["weighted_sum"] / agg["sample_size_total"]
-
     pivot = agg.pivot_table(
         index=level,
         columns="measure",
@@ -181,14 +195,20 @@ def rank_measure_changes(
         abs_change, pct_change, direction
     Sorted by abs(abs_change) descending.
     """
+    validate_dataframe(
+        df,
+        _REQUIRED_LONG_COLS,
+        name="df (rank_measure_changes)",
+    )
     if measures is None:
         measures = DEFAULT_MEASURES
 
     trends = compare_measures_over_time(df, region, measures)
     if trends.empty:
         return pd.DataFrame(columns=[
-            "measure", "start_year", "end_year", "start_value",
-            "end_value", "abs_change", "pct_change", "direction",
+            "measure", "start_year", "end_year",
+            "start_value", "end_value",
+            "abs_change", "pct_change", "direction",
         ])
 
     records = []
@@ -199,10 +219,8 @@ def rank_measure_changes(
 
         sy = start_year if start_year is not None else int(m_data["year"].min())
         ey = end_year if end_year is not None else int(m_data["year"].max())
-
         start_row = m_data[m_data["year"] == sy]
         end_row = m_data[m_data["year"] == ey]
-
         if start_row.empty or end_row.empty:
             # Fall back to closest available years
             start_row = m_data.iloc[[0]]
@@ -239,12 +257,12 @@ def generate_cross_measure_summary(
     """Generate a comprehensive cross-measure summary for a region.
 
     Returns a dictionary with:
-    - 'snapshot': prevalence for each measure in the given year
-    - 'trends': year-by-year prevalence for all measures
-    - 'correlations': pairwise correlations between measures
-    - 'changes': measures ranked by largest change over the full period
-    - 'region': the region name
-    - 'year': the snapshot year
+        - 'snapshot':      prevalence for each measure in the given year
+        - 'trends':        year-by-year prevalence for all measures
+        - 'correlations':  pairwise correlations between measures
+        - 'changes':       measures ranked by largest change over the full period
+        - 'region':        the region name
+        - 'year':          the snapshot year
 
     Parameters
     ----------
@@ -261,6 +279,11 @@ def generate_cross_measure_summary(
     -------
     dict with keys: region, year, snapshot, trends, correlations, changes.
     """
+    validate_dataframe(
+        df,
+        _REQUIRED_LONG_COLS,
+        name="df (generate_cross_measure_summary)",
+    )
     if measures is None:
         measures = DEFAULT_MEASURES
 
@@ -295,8 +318,8 @@ def compare_all_regions_cross_measure(
 ) -> pd.DataFrame:
     """Build a table of measure values for ALL regions in a given year.
 
-    Rows = regions, columns = measures.  Useful for a quick "which region
-    is highest/lowest on each measure" comparison.
+    Rows = regions, columns = measures.
+    Useful for a quick "which region is highest/lowest on each measure" comparison.
 
     Parameters
     ----------
@@ -311,12 +334,16 @@ def compare_all_regions_cross_measure(
     -------
     DataFrame with one row per region and one column per measure.
     """
+    validate_dataframe(
+        df,
+        _REQUIRED_LONG_COLS,
+        name="df (compare_all_regions_cross_measure)",
+    )
     if measures is None:
         measures = DEFAULT_MEASURES
 
     df = _add_region(df)
     regions = sorted(df["region"].dropna().unique())
-
     frames = []
     for region in regions:
         if region == "Other":
@@ -328,12 +355,9 @@ def compare_all_regions_cross_measure(
 
     if not frames:
         return pd.DataFrame()
-
     combined = pd.concat(frames, ignore_index=True)
-
     if year is None:
         year = int(combined["year"].max())
-
     snapshot = combined[combined["year"] == year]
     return snapshot.pivot_table(
         index="region",

--- a/src/regional_summary.py
+++ b/src/regional_summary.py
@@ -1,8 +1,10 @@
 """regional_summary.py
 
 Build formatted comparison tables that span all five regions and all three
-health indicators.  Every public function returns a plain DataFrame that the
-caller can write to CSV, render in a notebook, or format further.
+health indicators.
+
+Every public function returns a plain DataFrame that the caller can write to
+CSV, render in a notebook, or format further.
 """
 
 import numpy as np
@@ -10,9 +12,16 @@ import pandas as pd
 
 from src.region_mapping import REGIONS, STATE_TO_REGION
 from src.trend_analysis import compute_region_year_prevalence, compute_trend_slope
+from src.utils import validate_dataframe
 
 REGION_ORDER = ["Northeast", "Southeast", "Midwest", "Southwest", "West"]
 MEASURE_ORDER = ["obesity", "coverage", "smoking"]
+
+# Columns required for any of the public summary functions to operate.
+# Every public entry point validates its input against this list so a
+# malformed/renamed CSV produces an immediate, actionable error rather
+# than a cryptic KeyError later in the pipeline.
+_REQUIRED_INPUT_COLS = ["year", "state", "measure", "value", "sample_size"]
 
 
 def _attach_region(df: pd.DataFrame) -> pd.DataFrame:
@@ -23,7 +32,7 @@ def _attach_region(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _region_trends_all_measures(df: pd.DataFrame) -> pd.DataFrame:
-    """Weighted regional prevalence for every region × measure × year."""
+    """Weighted regional prevalence for every region x measure x year."""
     frames = []
     for measure in MEASURE_ORDER:
         ts = compute_region_year_prevalence(df, measure)
@@ -35,15 +44,16 @@ def _region_trends_all_measures(df: pd.DataFrame) -> pd.DataFrame:
 
 
 # ------------------------------------------------------------------
-# Table 1 – Latest-year snapshot: regions × measures
+# Table 1 - Latest-year snapshot: regions x measures
 # ------------------------------------------------------------------
 
 def latest_year_snapshot(df: pd.DataFrame) -> pd.DataFrame:
-    """Pivot the most recent year of data into a regions × measures matrix.
+    """Pivot the most recent year of data into a regions x measures matrix.
 
-    Returns a DataFrame with regions as rows, measures as columns,
-    and weighted prevalence (%) as values rounded to 1 decimal place.
+    Returns a DataFrame with regions as rows, measures as columns, and
+    weighted prevalence (%) as values rounded to 1 decimal place.
     """
+    validate_dataframe(df, _REQUIRED_INPUT_COLS, name="df (latest_year_snapshot)")
     rdf = _attach_region(df)
     all_ts = _region_trends_all_measures(rdf)
     if all_ts.empty:
@@ -51,7 +61,6 @@ def latest_year_snapshot(df: pd.DataFrame) -> pd.DataFrame:
 
     latest = int(all_ts["year"].max())
     snap = all_ts[all_ts["year"] == latest].copy()
-
     pivot = snap.pivot_table(
         index="region", columns="measure", values="prevalence_pct", aggfunc="mean"
     )
@@ -59,13 +68,12 @@ def latest_year_snapshot(df: pd.DataFrame) -> pd.DataFrame:
     pivot = pivot.round(1)
     pivot.index.name = "region"
     pivot.columns.name = None
-
     pivot.attrs["title"] = f"Regional Prevalence Snapshot ({latest})"
     return pivot
 
 
 # ------------------------------------------------------------------
-# Table 2 – Period change: start-year vs end-year per region/measure
+# Table 2 - Period change: start-year vs end-year per region/measure
 # ------------------------------------------------------------------
 
 def period_change_table(
@@ -75,9 +83,10 @@ def period_change_table(
 ) -> pd.DataFrame:
     """Change in weighted prevalence from *start_year* to *end_year*.
 
-    Returns one row per region × measure with columns:
+    Returns one row per region x measure with columns:
         region, measure, start_prev, end_prev, change_pp, pct_change
     """
+    validate_dataframe(df, _REQUIRED_INPUT_COLS, name="df (period_change_table)")
     rdf = _attach_region(df)
     all_ts = _region_trends_all_measures(rdf)
     if all_ts.empty:
@@ -98,7 +107,6 @@ def period_change_table(
         .rename(columns={"prevalence_pct": "end_prev"})
         [["region", "measure", "end_prev"]]
     )
-
     merged = pd.merge(start, end, on=["region", "measure"], how="inner")
     merged["change_pp"] = (merged["end_prev"] - merged["start_prev"]).round(2)
     merged["pct_change"] = (
@@ -119,15 +127,16 @@ def period_change_table(
 
 
 # ------------------------------------------------------------------
-# Table 3 – Trend slopes across all regions × measures
+# Table 3 - Trend slopes across all regions x measures
 # ------------------------------------------------------------------
 
 def trend_slopes_summary(df: pd.DataFrame) -> pd.DataFrame:
-    """Linear-trend slope (pp / year) and R² for every region × measure.
+    """Linear-trend slope (pp / year) and R-squared for every region x measure.
 
     Returns a wide-format table:
         region | obesity_slope | obesity_r2 | coverage_slope | ...
     """
+    validate_dataframe(df, _REQUIRED_INPUT_COLS, name="df (trend_slopes_summary)")
     rdf = _attach_region(df)
     all_ts = _region_trends_all_measures(rdf)
     if all_ts.empty:
@@ -146,14 +155,13 @@ def trend_slopes_summary(df: pd.DataFrame) -> pd.DataFrame:
     result = pieces[0]
     for p in pieces[1:]:
         result = pd.merge(result, p, on="region", how="outer")
-
     result["region"] = pd.Categorical(result["region"], REGION_ORDER, ordered=True)
     result = result.sort_values("region").reset_index(drop=True)
     return result
 
 
 # ------------------------------------------------------------------
-# Table 4 – Regional rankings for a single year
+# Table 4 - Regional rankings for a single year
 # ------------------------------------------------------------------
 
 def rank_regions_by_year(
@@ -166,6 +174,7 @@ def rank_regions_by_year(
 
     Returns columns: region, measure, prevalence_pct, rank.
     """
+    validate_dataframe(df, _REQUIRED_INPUT_COLS, name="df (rank_regions_by_year)")
     rdf = _attach_region(df)
     all_ts = _region_trends_all_measures(rdf)
     if all_ts.empty:
@@ -173,8 +182,8 @@ def rank_regions_by_year(
 
     if year is None:
         year = int(all_ts["year"].max())
-
     snap = all_ts[all_ts["year"] == year].copy()
+
     rows = []
     for measure in MEASURE_ORDER:
         msub = snap[snap["measure"] == measure].copy()
@@ -189,7 +198,7 @@ def rank_regions_by_year(
 
 
 # ------------------------------------------------------------------
-# Table 5 – Year-over-year wide matrix per measure
+# Table 5 - Year-over-year wide matrix per measure
 # ------------------------------------------------------------------
 
 def year_by_region_matrix(df: pd.DataFrame, measure: str) -> pd.DataFrame:
@@ -197,11 +206,11 @@ def year_by_region_matrix(df: pd.DataFrame, measure: str) -> pd.DataFrame:
 
     Useful for quick visual scanning of a single indicator across time.
     """
+    validate_dataframe(df, _REQUIRED_INPUT_COLS, name="df (year_by_region_matrix)")
     rdf = _attach_region(df)
     ts = compute_region_year_prevalence(rdf, measure)
     if ts.empty:
         return pd.DataFrame()
-
     pivot = ts.pivot_table(
         index="region", columns="year", values="prevalence_pct", aggfunc="mean"
     ).round(1)
@@ -212,15 +221,16 @@ def year_by_region_matrix(df: pd.DataFrame, measure: str) -> pd.DataFrame:
 
 
 # ------------------------------------------------------------------
-# Table 6 – Grand summary statistics
+# Table 6 - Grand summary statistics
 # ------------------------------------------------------------------
 
 def grand_summary(df: pd.DataFrame) -> pd.DataFrame:
     """High-level summary per region: mean, min, max prevalence and sample size
     across the full study period, broken out by measure.
 
-    Returns one row per region × measure.
+    Returns one row per region x measure.
     """
+    validate_dataframe(df, _REQUIRED_INPUT_COLS, name="df (grand_summary)")
     rdf = _attach_region(df)
     all_ts = _region_trends_all_measures(rdf)
     if all_ts.empty:
@@ -237,10 +247,8 @@ def grand_summary(df: pd.DataFrame) -> pd.DataFrame:
         )
         .reset_index()
     )
-
     for col in ["mean_prev", "min_prev", "max_prev"]:
         stats[col] = stats[col].round(2)
-
     stats["region"] = pd.Categorical(stats["region"], REGION_ORDER, ordered=True)
     stats["measure"] = pd.Categorical(stats["measure"], MEASURE_ORDER, ordered=True)
     return stats.sort_values(["measure", "region"]).reset_index(drop=True)

--- a/src/trend_analysis.py
+++ b/src/trend_analysis.py
@@ -8,6 +8,8 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 
+from src.utils import validate_dataframe
+
 
 def compute_region_year_prevalence(df: pd.DataFrame, measure: str) -> pd.DataFrame:
     """Compute weighted-average prevalence per region per year for a given measure.
@@ -23,12 +25,15 @@ def compute_region_year_prevalence(df: pd.DataFrame, measure: str) -> pd.DataFra
     -------
     DataFrame with columns: region, year, measure, prevalence_pct, sample_size_total.
     """
+    validate_dataframe(
+        df,
+        ["year", "region", "measure", "value", "sample_size"],
+        name="df (compute_region_year_prevalence)",
+    )
     sub = df[df["measure"] == measure].copy()
     if sub.empty:
         return pd.DataFrame(columns=["region", "year", "measure", "prevalence_pct", "sample_size_total"])
-
     sub["weighted"] = sub["value"] * sub["sample_size"]
-
     agg = sub.groupby(["region", "year"], as_index=False).agg(
         weighted_sum=("weighted", "sum"),
         sample_size_total=("sample_size", "sum"),
@@ -41,8 +46,8 @@ def compute_region_year_prevalence(df: pd.DataFrame, measure: str) -> pd.DataFra
 def compute_trend_slope(regional_ts: pd.DataFrame) -> pd.DataFrame:
     """Fit a linear trend to each region's prevalence time series.
 
-    Uses ``np.polyfit(years, values, deg=1)`` — ordinary least-squares
-    polynomial fit of degree 1 — to estimate the average annual change
+    Uses ``np.polyfit(years, values, deg=1)`` -- ordinary least-squares
+    polynomial fit of degree 1 -- to estimate the average annual change
     (percentage points per year) for each region.
 
     Parameters
@@ -54,14 +59,19 @@ def compute_trend_slope(regional_ts: pd.DataFrame) -> pd.DataFrame:
     Returns
     -------
     DataFrame with columns:
-        region          — region name
-        slope_pp_yr     — estimated change in prevalence (pp) per year
-        intercept       — fitted value at year 0 (use for prediction only)
-        r_squared       — coefficient of determination (fit quality, 0–1)
-        p_value         — p-value for the slope (is the trend significant?)
-        std_err         — standard error of the slope
-        years_n         — number of data points used in the fit
+        region        -- region name
+        slope_pp_yr   -- estimated change in prevalence (pp) per year
+        intercept     -- fitted value at year 0 (use for prediction only)
+        r_squared     -- coefficient of determination (fit quality, 0-1)
+        p_value       -- p-value for the slope (is the trend significant?)
+        std_err       -- standard error of the slope
+        years_n       -- number of data points used in the fit
     """
+    validate_dataframe(
+        regional_ts,
+        ["region", "year", "prevalence_pct"],
+        name="regional_ts (compute_trend_slope)",
+    )
     records = []
     for region, group in regional_ts.groupby("region"):
         group = group.sort_values("year")
@@ -97,7 +107,6 @@ def compute_trend_slope(regional_ts: pd.DataFrame) -> pd.DataFrame:
                 "years_n": len(years),
             }
         )
-
     return pd.DataFrame(records).sort_values("slope_pp_yr", ascending=False)
 
 
@@ -117,6 +126,11 @@ def pivot_regional_trends(regional_ts: pd.DataFrame) -> pd.DataFrame:
     -------
     DataFrame with regions as the index and one column per year.
     """
+    validate_dataframe(
+        regional_ts,
+        ["region", "year", "prevalence_pct"],
+        name="regional_ts (pivot_regional_trends)",
+    )
     return regional_ts.pivot_table(
         index="region",
         columns="year",
@@ -129,9 +143,10 @@ def pivot_measures_by_region(all_trends: pd.DataFrame, year: int) -> pd.DataFram
     """Pivot all measures for a single year into a cross-region comparison.
 
     Produces a table like:
+
         region     obesity  coverage  smoking
-        Midwest      36.0      88.2     17.1
-        West         30.2      87.5     12.4
+        Midwest    36.0     88.2      17.1
+        West       30.2     87.5      12.4
         ...
 
     Parameters
@@ -144,9 +159,13 @@ def pivot_measures_by_region(all_trends: pd.DataFrame, year: int) -> pd.DataFram
 
     Returns
     -------
-    DataFrame with regions as rows and one column per measure,
-    sorted by region name.
+    DataFrame with regions as rows and one column per measure, sorted by region name.
     """
+    validate_dataframe(
+        all_trends,
+        ["region", "year", "measure", "prevalence_pct"],
+        name="all_trends (pivot_measures_by_region)",
+    )
     subset = all_trends[all_trends["year"] == year]
     return subset.pivot_table(
         index="region",
@@ -173,10 +192,15 @@ def compute_rolling_avg(
 
     Returns
     -------
-    Copy of ``regional_ts`` with an extra column ``rolling_avg``
-    containing the centred rolling mean. Rows where the window
-    cannot be fully applied have NaN in ``rolling_avg``.
+    Copy of ``regional_ts`` with an extra column ``rolling_avg`` containing
+    the centred rolling mean. Rows where the window cannot be fully applied
+    have NaN in ``rolling_avg``.
     """
+    validate_dataframe(
+        regional_ts,
+        ["region", "year", "prevalence_pct"],
+        name="regional_ts (compute_rolling_avg)",
+    )
     out = regional_ts.sort_values(["region", "year"]).copy()
     out["rolling_avg"] = (
         out.groupby("region")["prevalence_pct"]
@@ -202,6 +226,11 @@ def compute_convergence(regional_ts: pd.DataFrame) -> pd.DataFrame:
         trend is 'converging' if std decreased from first to last year,
         'diverging' otherwise.
     """
+    validate_dataframe(
+        regional_ts,
+        ["year", "prevalence_pct"],
+        name="regional_ts (compute_convergence)",
+    )
     yearly_std = (
         regional_ts.groupby("year")["prevalence_pct"]
         .agg(lambda vals: float(np.std(vals.to_numpy(), ddof=0)))
@@ -238,9 +267,13 @@ def compare_covid_periods(
 
     Returns
     -------
-    DataFrame with columns:
-        region, pre_avg, post_avg, delta, pct_change
+    DataFrame with columns: region, pre_avg, post_avg, delta, pct_change
     """
+    validate_dataframe(
+        regional_ts,
+        ["region", "year", "prevalence_pct"],
+        name="regional_ts (compare_covid_periods)",
+    )
     pre_df = (
         regional_ts[regional_ts["year"].between(pre[0], pre[1])]
         .groupby("region", as_index=False)["prevalence_pct"]
@@ -275,8 +308,8 @@ def compare_covid_periods_by_measure(
     Parameters
     ----------
     df : DataFrame
-        Long-format DataFrame containing region, year, measure,
-        and prevalence columns.
+        Long-format DataFrame containing region, year, measure, and prevalence
+        columns.
     pre : tuple[int, int]
         Inclusive pre-COVID year window.
     post : tuple[int, int]
@@ -293,30 +326,26 @@ def compare_covid_periods_by_measure(
     Returns
     -------
     DataFrame
-        Columns:
-        measure, region, pre_avg, post_avg, delta, pct_change
+        Columns: measure, region, pre_avg, post_avg, delta, pct_change
     """
-    required_regions = ["Northeast", "Southeast",
-                        "Midwest", "Southwest", "West"]
+    required_regions = ["Northeast", "Southeast", "Midwest", "Southwest", "West"]
     required_measures = ["coverage", "obesity", "smoking"]
 
-    required_cols = {region_col, year_col, measure_col, value_col}
-    missing = required_cols - set(df.columns)
-    if missing:
-        raise ValueError(f"Missing required columns: {sorted(missing)}")
+    validate_dataframe(
+        df,
+        [region_col, year_col, measure_col, value_col],
+        name="df (compare_covid_periods_by_measure)",
+    )
 
     data = df.copy()
-
     data = data[
         data[region_col].isin(required_regions)
         & data[measure_col].isin(required_measures)
     ].copy()
 
     results = []
-
     for measure in required_measures:
         measure_df = data[data[measure_col] == measure].copy()
-
         if measure_df.empty:
             continue
 
@@ -333,18 +362,15 @@ def compare_covid_periods_by_measure(
             pre=pre,
             post=post,
         )
-
         comparison.insert(0, "measure", measure)
         results.append(comparison)
 
     if not results:
         return pd.DataFrame(
-            columns=["measure", "region", "pre_avg",
-                     "post_avg", "delta", "pct_change"]
+            columns=["measure", "region", "pre_avg", "post_avg", "delta", "pct_change"]
         )
 
     final = pd.concat(results, ignore_index=True)
-
     final["region"] = pd.Categorical(
         final["region"],
         categories=required_regions,
@@ -355,6 +381,5 @@ def compare_covid_periods_by_measure(
         categories=required_measures,
         ordered=True,
     )
-
     final = final.sort_values(["measure", "region"]).reset_index(drop=True)
     return final

--- a/src/utils.py
+++ b/src/utils.py
@@ -33,3 +33,44 @@ def safe_write_csv(df: pd.DataFrame, path: Path):
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     df.to_csv(path, index=False)
+
+
+def validate_dataframe(
+    df: pd.DataFrame,
+    required_cols: list[str],
+    name: str = "DataFrame",
+) -> None:
+    """Validate that a DataFrame contains the required columns.
+
+    This is a lightweight upfront guard intended to be called at the top of
+    public functions in the analysis modules. It produces an immediate,
+    actionable error rather than letting downstream code fail with a cryptic
+    KeyError or, worse, silently produce wrong results.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to validate.
+    required_cols : list[str]
+        Column names that must be present in df.
+    name : str
+        Optional human-friendly name for the DataFrame, used in the error
+        message (e.g. "regional_ts").
+
+    Raises
+    ------
+    TypeError
+        If df is not a pandas DataFrame.
+    ValueError
+        If any of the required columns are missing.
+    """
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError(
+            f"{name} must be a pandas DataFrame, got {type(df).__name__}"
+        )
+    missing = [c for c in required_cols if c not in df.columns]
+    if missing:
+        raise ValueError(
+            f"{name} missing required columns: {missing} "
+            f"(got columns: {list(df.columns)})"
+        )


### PR DESCRIPTION
Closes #42.

## Summary

Adds a small shared `validate_dataframe` helper to `src/utils.py` and calls it at the top of every public function in the four core analysis modules:

- `src/trend_analysis.py`
- - `src/covid_analysis.py`
- - `src/regional_summary.py`
- - `src/cross_measure.py`
## Why

Across ~1,900 lines of source code there were only ~15 `raise` statements. Functions throughout the codebase assumed columns like `year`, `state`, `measure`, `value`, and `sample_size` always exist and are the correct type, but there was no consistent upfront guard. If the CDC API schema changes or a processed CSV is regenerated differently, the result is cryptic downstream errors or, worse, silently wrong results.

## What `validate_dataframe` does

```python
def validate_dataframe(df, required_cols, name="DataFrame"):
    if not isinstance(df, pd.DataFrame):
        raise TypeError(f"{name} must be a pandas DataFrame, got {type(df).__name__}")
    missing = [c for c in required_cols if c not in df.columns]
    if missing:
        raise ValueError(
            f"{name} missing required columns: {missing} "
            f"(got columns: {list(df.columns)})"
        )
```

It fails fast with an actionable error message that names both the function it was called from and the columns that were missing.

## Validated columns by entry point

- `compute_region_year_prevalence`: `year, region, measure, value, sample_size`
- - `compute_trend_slope`, `pivot_regional_trends`, `compute_rolling_avg`, `compare_covid_periods`: `region, year, prevalence_pct`
- - `pivot_measures_by_region`: `region, year, measure, prevalence_pct`
- - `compute_convergence`: `year, prevalence_pct`
- - `compare_covid_periods_by_measure`: caller-supplied `region_col, year_col, measure_col, value_col`
- - `compare_trend_slopes`, `compute_disruption_score`, `compute_recovery_trajectory`, `rank_measures_by_disruption`, `build_covid_summary_table`: `region, year, prevalence_pct` (plus a dict-type guard for the `*_by_measure` helpers)
- - All public `regional_summary` tables: `year, state, measure, value, sample_size`
- - All public `cross_measure` functions: `year, measure, value, sample_size` (plus a `state`/`region` check inside `_add_region`)
## Backwards compatibility

The new validation is strictly additive:

- Valid inputs that worked before still work.
- - Inputs that previously produced cryptic `KeyError`s now raise a clear `ValueError` from the same call site.
- - Inputs that are not DataFrames now raise `TypeError` instead of `AttributeError`.
No behavior changes for valid data; existing tests should continue to pass.